### PR TITLE
DailyChannelRanking の height を 300 にした

### DIFF
--- a/src/models/Rankings/DailyChannelRanking.tsx
+++ b/src/models/Rankings/DailyChannelRanking.tsx
@@ -35,7 +35,7 @@ export const DailyChannelRanking: FC<DailyRankingProps> = ({ range }) => {
       <Bar
         options={commonChartOptions}
         data={data}
-        height={200}
+        height={300}
         className={clsx(loading && 'opacity-70')}
       />
     </div>


### PR DESCRIPTION
height が違うことによって、スマホから見たときに DailyChannelRanking だけグラフが見づらくなっていたので、 他の component を height を統一しました

<img width="379" alt="image" src="https://github.com/cp-20/traQing/assets/18237819/07274773-dde3-4ac6-881e-422af68dc0d0">
