### PR TITLE
fix: APIプレイグラウンドで項目を未選択にできてしまうバグを修正

### DIFF
--- a/apps/client/src/pages/playground/PlaygroundPage.tsx
+++ b/apps/client/src/pages/playground/PlaygroundPage.tsx
@@ -146,11 +146,12 @@ export const PlaygroundPage: FC = () => {
               data={APIKindOptions}
               value={apiKind}
               onChange={(v) => setApiKind(v as APIKind)}
+              allowDeselect={false}
             />
           </div>
           <div className="grid grid-cols-2 max-md:grid-cols-1 gap-2">
             <PlaygroundFilters apiKind={apiKind} reducer={filter} />
-            <Select label="取得件数" data={limitKindOptions} value={limit} onChange={(v) => setLimit(v as LimitKind)} />
+            <Select label="取得件数" data={limitKindOptions} value={limit} onChange={(v) => setLimit(v as LimitKind)} allowDeselect={false}/>
             <div>
               <div className="text-sm/[1.75] font-medium">取得期間</div>
               {datePicker.render({ buttonProps: { fullWidth: true } })}

--- a/apps/client/src/pages/playground/usePlaygroundFilters.tsx
+++ b/apps/client/src/pages/playground/usePlaygroundFilters.tsx
@@ -70,24 +70,27 @@ const MessagesFilter: FC<PlaygroundFilter<'messages'>> = ({ reducer }) => {
     <>
       <UserSelect reducer={reducer.actions.userSelectReducer} textInputProps={{ label: 'ユーザー名' }} />
       <ChannelSelect reducer={reducer.actions.channelSelectReducer} textInputProps={{ label: 'チャンネル名' }} />
-      <Select label="Botフィルタ" data={botKindOptions} value={botKind} onChange={(v) => setBotKind(v as BotKind)} />
+      <Select label="Botフィルタ" data={botKindOptions} value={botKind} onChange={(v) => setBotKind(v as BotKind)} allowDeselect={false}/>
       <Select
         label="グループ化"
         data={groupByKindOptions.messages}
         value={groupByKind}
         onChange={(v) => setGroupByKind(v as GroupByKind['messages'])}
+        allowDeselect={false}
       />
       <Select
         label="ソート項目"
         data={orderByKindOptions.messages}
         value={orderByKind}
         onChange={(v) => setOrderByKind(v as OrderByKind['messages'])}
+        allowDeselect={false}
       />
       <Select
         label="昇順/降順"
         data={orderKindOptions}
         value={orderKind}
         onChange={(v) => setOrderKind(v as OrderKind)}
+        allowDeselect={false}
       />
     </>
   );


### PR DESCRIPTION
できました 🫶 

### 再現手順
APIプレイグラウンドで、「使用するAPI」などで既に選択されている項目を再び選択する